### PR TITLE
Create Board and Finished Sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bootstrap": "^4.6.0",
     "font-awesome": "^4.7.0",
     "react": "^17.0.1",
+    "react-beautiful-dnd": "^13.1.0",
     "react-bootstrap": "^1.5.2",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,14 @@
-import React from "react";
+import React, { Component } from "react";
 import "bootstrap/dist/css/bootstrap.min.css";
-import Amplify, { Auth, graphqlOperation } from "aws-amplify";
+import Amplify, { Auth } from "aws-amplify";
 import awsconfig from "./aws-exports";
-import { AmplifySignOut, withAuthenticator } from "@aws-amplify/ui-react";
+import { withAuthenticator } from "@aws-amplify/ui-react";
 import Layout from "./components/Layout/Layout";
 import "./index.css";
 
 Amplify.configure(awsconfig);
+class App extends Component {
 
-class App extends React.Component {
   async componentDidMount() {
     const { username } = await Auth.currentAuthenticatedUser();
 
@@ -20,8 +20,6 @@ class App extends React.Component {
   render() {
     return (
       <div>
-        {/* TODO: Put signout feature in layout component */}
-        {/* <AmplifySignOut /> */}
         <Layout />
       </div>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,6 @@ import "./index.css";
 
 Amplify.configure(awsconfig);
 class App extends Component {
-
   async componentDidMount() {
     const { username } = await Auth.currentAuthenticatedUser();
 

--- a/src/components/Dialogs/CreateBoardDialog.js
+++ b/src/components/Dialogs/CreateBoardDialog.js
@@ -7,8 +7,8 @@ import Form from "react-bootstrap/Form";
 class CreateBoardDialog extends Component {
   state = {
     value: {
-      route: "/board",
-      textFieldValue: "",
+      route: "/board", // Static variable... subject to change potentially
+      dialogTitle: "",
     },
   };
 
@@ -68,9 +68,8 @@ class CreateBoardDialog extends Component {
 
   handleInputChange(element) {
     this.setState({
-      value: { textFieldValue: element.target.value, route: "/board" },
+      value: { ...this.state.value, dialogTitle: element.target.value },
     });
-    console.warn(this.state);
   }
 }
 

--- a/src/components/Dialogs/DialogWrapper.js
+++ b/src/components/Dialogs/DialogWrapper.js
@@ -13,7 +13,6 @@ class DialogWrapper extends Component {
   };
 
   render() {
-
     switch (this.props.dialog.dialogType) {
       case "optionDialog": {
         return (
@@ -69,21 +68,19 @@ class DialogWrapper extends Component {
 
   handleSubmitDialog = (value) => {
     if (value.route) {
-      
       this.props.history.push({
         pathname: value.route,
         state: value,
       });
 
-      this.setState({ ...this.state, redirect: true })
-    } 
-    else {
+      this.setState({ ...this.state, redirect: true });
+    } else {
       this.setState({ ...this.state, show: false });
     }
   };
 
   resetRedirectState() {
-    this.setState({ ...this.state, redirect: false, });
+    this.setState({ ...this.state, redirect: false });
   }
 
   resetShowState() {

--- a/src/components/Dialogs/DialogWrapper.js
+++ b/src/components/Dialogs/DialogWrapper.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import OptionDialog from "./OptionDialog";
-import { Redirect } from "react-router";
 import CreateBoardDialog from "./CreateBoardDialog";
+import { withRouter } from "react-router-dom";
 
 /**
  * Wrapper component around various dialog components
@@ -10,22 +10,9 @@ class DialogWrapper extends Component {
   state = {
     show: this.props.dialog.show,
     redirect: false,
-    redirectRoute: "",
-    value: {},
   };
 
   render() {
-    if (this.state.redirect) {
-      return (
-        <Redirect
-          push
-          to={{
-            pathname: this.state.redirectRoute,
-            state: this.state.value,
-          }}
-        />
-      );
-    }
 
     switch (this.props.dialog.dialogType) {
       case "optionDialog": {
@@ -57,7 +44,6 @@ class DialogWrapper extends Component {
             onSubmit={this.handleSubmitDialog}
           />
         );
-        break;
       }
       default: {
         return (
@@ -83,23 +69,26 @@ class DialogWrapper extends Component {
 
   handleSubmitDialog = (value) => {
     if (value.route) {
-      this.setState({
-        redirectRoute: value.route,
-        redirect: true,
-        value: value,
+      
+      this.props.history.push({
+        pathname: value.route,
+        state: value,
       });
-    } else {
-      this.setState({ show: false });
+
+      this.setState({ ...this.state, redirect: true })
+    } 
+    else {
+      this.setState({ ...this.state, show: false });
     }
   };
 
   resetRedirectState() {
-    this.setState({ redirect: false, redirectRoute: "" });
+    this.setState({ ...this.state, redirect: false, });
   }
 
   resetShowState() {
-    this.setState({ show: false });
+    this.setState({ ...this.state, show: false });
   }
 }
 
-export default DialogWrapper;
+export default withRouter(DialogWrapper);

--- a/src/components/Dialogs/OptionDialog.js
+++ b/src/components/Dialogs/OptionDialog.js
@@ -51,7 +51,7 @@ class OptionDialog extends Component {
             >
               OK
             </Button>
-            <Button variant="primary" onClick={() => this.props.onClose()}>
+            <Button variant="secondary" onClick={() => this.props.onClose()}>
               Cancel
             </Button>
           </Modal.Footer>

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -25,7 +25,6 @@ class Layout extends Component {
   };
 
   render() {
-
     return (
       <React.Fragment>
         <div className="App">

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -25,6 +25,7 @@ class Layout extends Component {
   };
 
   render() {
+
     return (
       <React.Fragment>
         <div className="App">

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -40,7 +40,7 @@ class NavBar extends Component {
             {this.state.navBarItems.map((navBarItem) => (
               <li
                 key={navBarItem.id + "-list"}
-                className="nav-item px-3 navbar-icons"
+                className="nav-item px-3 selectable-item"
               >
                 <NavBarItem
                   key={navBarItem.id}
@@ -62,14 +62,15 @@ class NavBar extends Component {
   }
 
   resetRedirectState() {
-    this.setState({ redirect: false, redirectRoute: "" });
+    this.setState({ ...this.state, redirect: false, redirectRoute: "" });
   }
 
   handleClicked = (navBarItem) => {
     if (navBarItem.displayDialogComponent) {
       this.props.showDialog(dialogData);
-    } else if (navBarItem.route) {
-      this.setState({ redirect: true, redirectRoute: navBarItem.route });
+    } 
+    else if (navBarItem.route) {
+      this.setState({ ...this.state, redirect: true, redirectRoute: navBarItem.route });
     }
   };
 }

--- a/src/components/NavBar/NavBar.js
+++ b/src/components/NavBar/NavBar.js
@@ -68,9 +68,12 @@ class NavBar extends Component {
   handleClicked = (navBarItem) => {
     if (navBarItem.displayDialogComponent) {
       this.props.showDialog(dialogData);
-    } 
-    else if (navBarItem.route) {
-      this.setState({ ...this.state, redirect: true, redirectRoute: navBarItem.route });
+    } else if (navBarItem.route) {
+      this.setState({
+        ...this.state,
+        redirect: true,
+        redirectRoute: navBarItem.route,
+      });
     }
   };
 }

--- a/src/components/SideBar/SideBar.js
+++ b/src/components/SideBar/SideBar.js
@@ -9,22 +9,22 @@ import { Nav, Dropdown } from "react-bootstrap";
 import classNames from "classnames";
 import { createBoardData } from "./SideBarConstant";
 import { AmplifySignOut } from "@aws-amplify/ui-react";
-import { API, graphqlOperation } from 'aws-amplify';
-import * as queries from '../../graphql/queries';
+import { API, graphqlOperation } from "aws-amplify";
+import * as queries from "../../graphql/queries";
 
 class SideBar extends Component {
-
   state = {
-    nests: []
-  }
+    nests: [],
+  };
 
   customToggle = React.forwardRef(({ children, onClick }, ref) => (
     <div
-    ref={ref}
-    onClick={(e) => {
-      e.preventDefault();
-      onClick(e);
-    }}>
+      ref={ref}
+      onClick={(e) => {
+        e.preventDefault();
+        onClick(e);
+      }}
+    >
       {children}
     </div>
   ));
@@ -36,7 +36,11 @@ class SideBar extends Component {
         <div className="profile-view">
           <Dropdown>
             <Dropdown.Toggle as={this.customToggle}>
-              <FontAwesomeIcon className="selectable-item" icon={faUserCircle} size="8x" />
+              <FontAwesomeIcon
+                className="selectable-item"
+                icon={faUserCircle}
+                size="8x"
+              />
             </Dropdown.Toggle>
             <Dropdown.Menu align="right" className="align-items-center">
               {/* For now, comment the settings drop down until we have a set plan for it going forward */}
@@ -44,7 +48,7 @@ class SideBar extends Component {
                 <i className={'fa fa-cog mr-3'}></i>Settings
               </Dropdown.Item> */}
               <Dropdown.Item eventKey="2" className="m-1 align-items-center">
-                <i className={'fa fa-sign-out'}></i>
+                <i className={"fa fa-sign-out"}></i>
                 <AmplifySignOut />
               </Dropdown.Item>
             </Dropdown.Menu>
@@ -71,7 +75,10 @@ class SideBar extends Component {
                 {this.state.nests.map((nest, index) => (
                   <Dropdown.Item key={index} eventKey={index}>
                     <div>
-                      <FontAwesomeIcon icon={faClipboardList} className="mr-3" />
+                      <FontAwesomeIcon
+                        icon={faClipboardList}
+                        className="mr-3"
+                      />
                       {nest.name}
                     </div>
                   </Dropdown.Item>
@@ -79,7 +86,6 @@ class SideBar extends Component {
               </Dropdown.Menu>
             </Dropdown>
           </Nav.Item>
-
         </Nav>
       </div>
     );
@@ -90,24 +96,19 @@ class SideBar extends Component {
   }
 
   getNestsForUser() {
-    
-    API.graphql(graphqlOperation(queries.nests)).then(
-      value => {
-        if(value.data.nests) {
-          const nests = value.data.nests.map(nest => this.parseNest(nest));
-          this.setState({ nests: nests });
-        }
+    API.graphql(graphqlOperation(queries.nests)).then((value) => {
+      if (value.data.nests) {
+        const nests = value.data.nests.map((nest) => this.parseNest(nest));
+        this.setState({ nests: nests });
       }
-    );
-
+    });
   }
-  
+
   handleClicked = (route) => {};
 
   parseNest(nest) {
-    return { name: nest.name, nestId: nest.nestId }
+    return { name: nest.name, nestId: nest.nestId };
   }
-
 }
 
 export default SideBar;

--- a/src/components/SideBar/SideBar.js
+++ b/src/components/SideBar/SideBar.js
@@ -11,6 +11,7 @@ import { createBoardData } from "./SideBarConstant";
 import { AmplifySignOut } from "@aws-amplify/ui-react";
 import { API, graphqlOperation } from "aws-amplify";
 import * as queries from "../../graphql/queries";
+import { withRouter } from "react-router-dom";
 
 class SideBar extends Component {
   state = {
@@ -74,7 +75,7 @@ class SideBar extends Component {
               <Dropdown.Menu align="right">
                 {this.state.nests.map((nest, index) => (
                   <Dropdown.Item key={index} eventKey={index}>
-                    <div>
+                    <div onClick={() => this.handleClicked(nest)}>
                       <FontAwesomeIcon
                         icon={faClipboardList}
                         className="mr-3"
@@ -104,11 +105,18 @@ class SideBar extends Component {
     });
   }
 
-  handleClicked = (route) => {};
+  handleClicked(nest) {
+    if (nest.nestId) {
+      this.props.history.push({
+        pathname: "/board", // Can keep as static for now...
+        state: nest,
+      });
+    }
+  }
 
   parseNest(nest) {
     return { name: nest.name, nestId: nest.nestId };
   }
 }
 
-export default SideBar;
+export default withRouter(SideBar);

--- a/src/components/SideBar/SideBar.js
+++ b/src/components/SideBar/SideBar.js
@@ -5,18 +5,50 @@ import {
   faClipboardList,
   faUserCircle,
 } from "@fortawesome/free-solid-svg-icons";
-import { Nav, Button } from "react-bootstrap";
+import { Nav, Dropdown } from "react-bootstrap";
 import classNames from "classnames";
 import { createBoardData } from "./SideBarConstant";
+import { AmplifySignOut } from "@aws-amplify/ui-react";
+import { API, graphqlOperation } from 'aws-amplify';
+import * as queries from '../../graphql/queries';
 
 class SideBar extends Component {
+
+  state = {
+    nests: []
+  }
+
+  customToggle = React.forwardRef(({ children, onClick }, ref) => (
+    <div
+    ref={ref}
+    onClick={(e) => {
+      e.preventDefault();
+      onClick(e);
+    }}>
+      {children}
+    </div>
+  ));
+
   render() {
     return (
       <div className={classNames("sidebar", { "is-open": this.props.isOpen })}>
+        <br />
         <div className="profile-view">
-          <Button variant="link" style={{ color: "#fff" }} className="mt-4">
-            <FontAwesomeIcon icon={faUserCircle} size="8x" />
-          </Button>
+          <Dropdown>
+            <Dropdown.Toggle as={this.customToggle}>
+              <FontAwesomeIcon className="selectable-item" icon={faUserCircle} size="8x" />
+            </Dropdown.Toggle>
+            <Dropdown.Menu align="right" className="align-items-center">
+              {/* For now, comment the settings drop down until we have a set plan for it going forward */}
+              {/* <Dropdown.Item className="align-items-center m-1" eventKey="1">
+                <i className={'fa fa-cog mr-3'}></i>Settings
+              </Dropdown.Item> */}
+              <Dropdown.Item eventKey="2" className="m-1 align-items-center">
+                <i className={'fa fa-sign-out'}></i>
+                <AmplifySignOut />
+              </Dropdown.Item>
+            </Dropdown.Menu>
+          </Dropdown>
         </div>
 
         <Nav className="flex-column pt-2">
@@ -27,17 +59,55 @@ class SideBar extends Component {
             </Nav.Link>
           </Nav.Item>
 
-          <Nav.Item>
-            <Nav.Link>
-              <FontAwesomeIcon icon={faClipboardList} className="mr-2" />
-              My Boards
-            </Nav.Link>
+          <Nav.Item className="active nav-link">
+            <Dropdown>
+              <Dropdown.Toggle as={this.customToggle}>
+                <div className="selectable-item">
+                  <FontAwesomeIcon icon={faClipboardList} className="mr-2" />
+                  My Boards
+                </div>
+              </Dropdown.Toggle>
+              <Dropdown.Menu align="right">
+                {this.state.nests.map((nest, index) => (
+                  <Dropdown.Item key={index} eventKey={index}>
+                    <div>
+                      <FontAwesomeIcon icon={faClipboardList} className="mr-3" />
+                      {nest.name}
+                    </div>
+                  </Dropdown.Item>
+                ))}
+              </Dropdown.Menu>
+            </Dropdown>
           </Nav.Item>
+
         </Nav>
       </div>
     );
   }
+
+  componentDidMount() {
+    this.getNestsForUser();
+  }
+
+  getNestsForUser() {
+    
+    API.graphql(graphqlOperation(queries.nests)).then(
+      value => {
+        if(value.data.nests) {
+          const nests = value.data.nests.map(nest => this.parseNest(nest));
+          this.setState({ nests: nests });
+        }
+      }
+    );
+
+  }
+  
   handleClicked = (route) => {};
+
+  parseNest(nest) {
+    return { name: nest.name, nestId: nest.nestId }
+  }
+
 }
 
 export default SideBar;

--- a/src/components/UserStory/UserStoryCard.js
+++ b/src/components/UserStory/UserStoryCard.js
@@ -6,6 +6,8 @@ import { Draggable } from "react-beautiful-dnd";
 class UserStoryCard extends Component {
   state = {};
 
+  DESCRIPTION_LENGTH = 150;
+
   render() {
     return (
       <Draggable
@@ -21,19 +23,39 @@ class UserStoryCard extends Component {
           >
             <Card>
               <Card.Body>
-                <Card.Title>{this.props.userStory.title}</Card.Title>
-                <Card.Subtitle className="mb-2 text-muted">
+                <Card.Title className="user-story-title-text">
+                  {this.props.userStory.title}
+                </Card.Title>
+                <Card.Subtitle className="mb-2 text-muted user-story-subtitle-text">
                   Assigned: {this.props.userStory.assignee}
                 </Card.Subtitle>
-                <Card.Text>{this.props.userStory.description}</Card.Text>
-                <Button variant="primary">View</Button>{" "}
-                <Button variant="danger">Delete</Button>
+                <Card.Text className="user-story-desc-text">
+                  {this.displayDescription(this.props.userStory.description)}
+                </Card.Text>
+                <Button className="user-story-desc-text" variant="primary">
+                  View
+                </Button>{" "}
+                <Button className="user-story-desc-text" variant="danger">
+                  Delete
+                </Button>
               </Card.Body>
             </Card>
           </div>
         )}
       </Draggable>
     );
+  }
+
+  /**
+   * Trims the description if we are over the allotted 150 characters, otherwise just returns the description
+   * as presently set.
+   * @param {string} description
+   * @returns
+   */
+  displayDescription(description) {
+    return description.length > 150
+      ? `${description.substr(0, this.DESCRIPTION_LENGTH).trim()}...`
+      : description;
   }
 }
 

--- a/src/components/UserStory/UserStoryCard.js
+++ b/src/components/UserStory/UserStoryCard.js
@@ -1,23 +1,32 @@
-import React, { Component } from 'react';
-import Card from 'react-bootstrap/Card';
-import Button from 'react-bootstrap/Button';
-import { Draggable } from 'react-beautiful-dnd';
+import React, { Component } from "react";
+import Card from "react-bootstrap/Card";
+import Button from "react-bootstrap/Button";
+import { Draggable } from "react-beautiful-dnd";
 
 class UserStoryCard extends Component {
-  
-  state = {  }
-  
-  render() { 
-    return ( 
-      <Draggable key={this.props.userStory.id} draggableId={this.props.userStory.id} index={this.props.index}>
+  state = {};
+
+  render() {
+    return (
+      <Draggable
+        key={this.props.userStory.id}
+        draggableId={this.props.userStory.id}
+        index={this.props.index}
+      >
         {(provided, snapshot) => (
-          <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
+          <div
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+            {...provided.dragHandleProps}
+          >
             <Card>
               <Card.Body>
                 <Card.Title>{this.props.userStory.title}</Card.Title>
-                <Card.Subtitle className="mb-2 text-muted">Assigned: {this.props.userStory.assignee}</Card.Subtitle>
+                <Card.Subtitle className="mb-2 text-muted">
+                  Assigned: {this.props.userStory.assignee}
+                </Card.Subtitle>
                 <Card.Text>{this.props.userStory.description}</Card.Text>
-                <Button variant="primary">View</Button>{' '}
+                <Button variant="primary">View</Button>{" "}
                 <Button variant="danger">Delete</Button>
               </Card.Body>
             </Card>
@@ -27,5 +36,5 @@ class UserStoryCard extends Component {
     );
   }
 }
- 
+
 export default UserStoryCard;

--- a/src/components/UserStory/UserStoryCard.js
+++ b/src/components/UserStory/UserStoryCard.js
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import Card from 'react-bootstrap/Card';
+import Button from 'react-bootstrap/Button';
+import { Draggable } from 'react-beautiful-dnd';
+
+class UserStoryCard extends Component {
+  
+  state = {  }
+  
+  render() { 
+    return ( 
+      <Draggable key={this.props.userStory.id} draggableId={this.props.userStory.id} index={this.props.index}>
+        {(provided, snapshot) => (
+          <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
+            <Card>
+              <Card.Body>
+                <Card.Title>{this.props.userStory.title}</Card.Title>
+                <Card.Subtitle className="mb-2 text-muted">Assigned: {this.props.userStory.assignee}</Card.Subtitle>
+                <Card.Text>{this.props.userStory.description}</Card.Text>
+                <Button variant="primary">View</Button>{' '}
+                <Button variant="danger">Delete</Button>
+              </Card.Body>
+            </Card>
+          </div>
+        )}
+      </Draggable>
+    );
+  }
+}
+ 
+export default UserStoryCard;

--- a/src/components/UserStory/UserStoryContainer.js
+++ b/src/components/UserStory/UserStoryContainer.js
@@ -27,10 +27,7 @@ class UserStoryContainer extends Component {
                 (userStory, index) => (
                   <div key={userStory.id}>
                     <br />
-                    <UserStoryCard
-                      userStory={userStory}
-                      index={index}
-                    />
+                    <UserStoryCard userStory={userStory} index={index} />
                   </div>
                 )
               )}

--- a/src/components/UserStory/UserStoryContainer.js
+++ b/src/components/UserStory/UserStoryContainer.js
@@ -1,32 +1,44 @@
-import React, { Component } from 'react';
-import UserStoryCard from './UserStoryCard';
-import { Droppable } from 'react-beautiful-dnd';
+import React, { Component } from "react";
+import UserStoryCard from "./UserStoryCard";
+import { Droppable } from "react-beautiful-dnd";
 
 class UserStoryContainer extends Component {
-  state = {  }
-  
-  render() { 
+  state = {};
+
+  render() {
     return (
       <React.Fragment>
         <Droppable droppableId={this.props.columnProperties.id}>
           {(provided, snapshot) => (
             <div {...provided.droppableProps} ref={provided.innerRef}>
               <div id="board-container-title" className="text-center">
-                <h5 className="display-4 text-black">{this.props.columnProperties.title}</h5>
+                <h5 className="display-4 text-black">
+                  {this.props.columnProperties.title}
+                </h5>
                 {this.props.columnProperties.showAddButton && (
-                  <i className="fa fa-plus-square-o" style={{ fontSize: "30px", cursor: "pointer" }} aria-hidden="true"></i>
+                  <i
+                    className="fa fa-plus-square-o"
+                    style={{ fontSize: "30px", cursor: "pointer" }}
+                    aria-hidden="true"
+                  ></i>
                 )}
               </div>
-              {this.props.columnProperties.userStories.map((userStory, index) => (
-                <div>
-                  <br />
-                  <UserStoryCard key={userStory.id} userStory={userStory} index={index} />
-                </div>
-              ))}
+              {this.props.columnProperties.userStories.map(
+                (userStory, index) => (
+                  <div key={userStory.id}>
+                    <br />
+                    <UserStoryCard
+                      userStory={userStory}
+                      index={index}
+                    />
+                  </div>
+                )
+              )}
+              {provided.placeholder}
             </div>
           )}
-      </Droppable>
-    </React.Fragment>  
+        </Droppable>
+      </React.Fragment>
     );
   }
 }

--- a/src/components/UserStory/UserStoryContainer.js
+++ b/src/components/UserStory/UserStoryContainer.js
@@ -10,19 +10,11 @@ class UserStoryContainer extends Component {
       <React.Fragment>
         <Droppable droppableId={this.props.columnProperties.id}>
           {(provided, snapshot) => (
-            <div {...provided.droppableProps} ref={provided.innerRef}>
-              <div id="board-container-title" className="text-center">
-                <h5 className="display-4 text-black">
-                  {this.props.columnProperties.title}
-                </h5>
-                {this.props.columnProperties.showAddButton && (
-                  <i
-                    className="fa fa-plus-square-o"
-                    style={{ fontSize: "30px", cursor: "pointer" }}
-                    aria-hidden="true"
-                  ></i>
-                )}
-              </div>
+            <div
+              {...provided.droppableProps}
+              id="user-story-container"
+              ref={provided.innerRef}
+            >
               {this.props.columnProperties.userStories.map(
                 (userStory, index) => (
                   <div key={userStory.id}>

--- a/src/components/UserStory/UserStoryContainer.js
+++ b/src/components/UserStory/UserStoryContainer.js
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+import UserStoryCard from './UserStoryCard';
+import { Droppable } from 'react-beautiful-dnd';
+
+class UserStoryContainer extends Component {
+  state = {  }
+  
+  render() { 
+    return (
+      <React.Fragment>
+        <Droppable droppableId={this.props.columnProperties.id}>
+          {(provided, snapshot) => (
+            <div {...provided.droppableProps} ref={provided.innerRef}>
+              <div id="board-container-title" className="text-center">
+                <h5 className="display-4 text-black">{this.props.columnProperties.title}</h5>
+                {this.props.columnProperties.showAddButton && (
+                  <i className="fa fa-plus-square-o" style={{ fontSize: "30px", cursor: "pointer" }} aria-hidden="true"></i>
+                )}
+              </div>
+              {this.props.columnProperties.userStories.map((userStory, index) => (
+                <div>
+                  <br />
+                  <UserStoryCard key={userStory.id} userStory={userStory} index={index} />
+                </div>
+              ))}
+            </div>
+          )}
+      </Droppable>
+    </React.Fragment>  
+    );
+  }
+}
+
+export default UserStoryContainer;

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,18 @@
   margin: auto !important;
 }
 
+/* General Classes */
+
+.selectable-item {
+  cursor: pointer;
+}
+
+.selectable-item:hover {
+  color: gray;
+}
+
+/* End General Classes */
+
 /* ---------------------------------------------------
     SIDEBAR CLASSES
 ----------------------------------------------------- */
@@ -115,6 +127,14 @@ li a.dropdown-toggle::after {
   font-size: 25px;
 }
 
+.nav-item .dropdown {
+  color: white;
+}
+
+#sidebar-container .nav-item {
+  color: white;
+}
+
 .navbar-brand {
   font-size: 2rem !important;
 }
@@ -146,6 +166,7 @@ li a.dropdown-toggle::after {
 }
 
 /* createDialogLabel */
+
 .createDialogLabel {
   font-size: 20px;
   margin-top: 10px;
@@ -161,6 +182,18 @@ li a.dropdown-toggle::after {
 
 /* End NavBar Classes */
 
+/* Dropdown Classes */
+
+.dropdown-item {
+  text-align: center;
+  display: flex;
+}
+
+.dropdown-item-icon {
+  padding-right: 0.5rem;
+}
+/* End Dropdown Classes */
+
 /* Dialog Classes */
 
 /* TO-DO Dialog CSS Classes Here */
@@ -170,3 +203,55 @@ li a.dropdown-toggle::after {
 /* Form Control Classes */
 
 /* End Form Control Classes */
+
+/* Amplify Classes */
+
+:host {
+  --padding: 0.2rem;
+}
+
+.dropdown-item :root {
+  --amplify-primary-color: white;
+  --amplify-primary-tint: gray;
+  --amplify-primary-shade: gray;
+  --amplify-primary-contrast: black;
+  /* --amplify-font-family: "DM Sans", sans-serif; */
+}
+
+/* End Amplify Classes */
+
+/* Board Classes */
+
+.container-height {
+  height: 75rem;
+}
+
+.max-height {
+  height: 100%;
+}
+
+#board-container.container .row {
+  height: 100%;
+}
+
+#board-container.container .col {
+  height: 100%;
+  border: 0.5px dashed #007bff;
+}
+
+#board-container.container {
+  max-width: none;
+  padding: 1.5rem;
+}
+
+#board-container-title h5 {
+  font-size: 2.5rem;
+  display: inline-block;
+  padding-right: 1rem;
+}
+
+#board-container-title {
+  border-bottom: 1px solid #007bff;
+}
+
+/* End Board Classes */

--- a/src/index.css
+++ b/src/index.css
@@ -245,13 +245,45 @@ li a.dropdown-toggle::after {
 }
 
 #board-container-title h5 {
-  font-size: 2.5rem;
+  font-size: 2rem;
   display: inline-block;
   padding-right: 1rem;
 }
 
 #board-container-title {
   border-bottom: 1px solid #007bff;
+}
+
+.board-column-properties {
+  width: 10% !important;
+  overflow-y: hidden;
+  padding-bottom: 5%;
+}
+
+#user-story-container {
+  overflow-y: auto;
+  height: 100%;
+}
+
+#user-story-container::-webkit-scrollbar {
+  display: none;
+}
+
+.nest-title {
+  color: slategray;
+  font-weight: 350;
+}
+
+.user-story-desc-text {
+  font-size: 0.8rem !important;
+}
+
+.user-story-title-text {
+  font-size: 1rem !important;
+}
+
+.user-story-subtitle-text {
+  font-size: 0.9rem !important;
 }
 
 /* End Board Classes */

--- a/src/pages/Board/Board.js
+++ b/src/pages/Board/Board.js
@@ -5,32 +5,74 @@ import Col from "react-bootstrap/Col";
 import UserStoryContainer from "../../components/UserStory/UserStoryContainer";
 import { NEST_MODEL } from "./BoardConstants";
 import { DragDropContext } from "react-beautiful-dnd";
+import { API, graphqlOperation } from "aws-amplify";
+import * as queries from "../../graphql/queries";
 
 class Board extends Component {
   state = {
+    nestName: "",
+    nestId: "",
     nest: NEST_MODEL,
   };
 
   render() {
     return (
-      <Container id="board-container" className="container-height">
-        <Row>
-          <DragDropContext onDragEnd={this.handleOnDragEnd}>
-            {this.state.nest.map((column) => (
-              <Col key={column.id}>
-                <UserStoryContainer key={column.id} columnProperties={column} />
-              </Col>
-            ))}
-          </DragDropContext>
-        </Row>
-      </Container>
+      <React.Fragment>
+        <h1 className="display-6 text-black text-center nest-title">
+          Welcome to the {this.state.nestName} Nest!
+        </h1>
+        <Container id="board-container" className="container-height">
+          <Row>
+            <DragDropContext onDragEnd={this.handleOnDragEnd}>
+              {this.state.nest.map((column) => (
+                <Col key={column.id} className="board-column-properties">
+                  <div id="board-container-title" className="text-center">
+                    <h5 className="display-4 text-black">{column.title}</h5>
+                    {column.showAddButton && (
+                      <i
+                        className="fa fa-plus-square-o"
+                        style={{ fontSize: "30px", cursor: "pointer" }}
+                        aria-hidden="true"
+                      ></i>
+                    )}
+                  </div>
+                  <UserStoryContainer
+                    key={column.id}
+                    columnProperties={column}
+                  />
+                </Col>
+              ))}
+            </DragDropContext>
+          </Row>
+        </Container>
+      </React.Fragment>
     );
   }
 
-  // Comment out for now to avoid warnings, will need to implement in future
-  // constructor(props) {
-  //   super(props);
-  // }
+  constructor(props) {
+    super(props);
+    // Temporarily, we can only get nest data from the props.location property (signifying we routed to the board) may change in the future
+    if (!!props.location) {
+      this.state = {
+        ...this.state,
+        nestId: props.location.state.nestId,
+        nestName: props.location.state.name,
+      };
+    }
+  }
+
+  componentDidMount() {
+    this.getNestData();
+  }
+
+  getNestData() {
+    API.graphql(
+      graphqlOperation(queries.nest, { nestId: this.state.nestId })
+    ).then((value) => {
+      // console.log('NEST DATA IS: ', value);
+      // TO-DO: Logic in here to set the neccessary state for the nest
+    });
+  }
 
   handleOnDragEnd = (result) => {
     if (!result.destination) {

--- a/src/pages/Board/Board.js
+++ b/src/pages/Board/Board.js
@@ -1,13 +1,12 @@
 import React, { Component } from "react";
-import Container from 'react-bootstrap/Container';
-import Row from 'react-bootstrap/Row';
-import Col from 'react-bootstrap/Col';
-import UserStoryContainer from '../../components/UserStory/UserStoryContainer';
-import { NEST_MODEL } from './BoardConstants';
-import { DragDropContext } from 'react-beautiful-dnd';
+import Container from "react-bootstrap/Container";
+import Row from "react-bootstrap/Row";
+import Col from "react-bootstrap/Col";
+import UserStoryContainer from "../../components/UserStory/UserStoryContainer";
+import { NEST_MODEL } from "./BoardConstants";
+import { DragDropContext } from "react-beautiful-dnd";
 
 class Board extends Component {
-  
   state = {
     nest: NEST_MODEL,
   };
@@ -17,7 +16,6 @@ class Board extends Component {
       <Container id="board-container" className="container-height">
         <Row>
           <DragDropContext onDragEnd={this.handleOnDragEnd}>
-            {console.log('BOARD COLUMNS IN RENDER IS: ', this.state.nest)}
             {this.state.nest.map((column) => (
               <Col key={column.id}>
                 <UserStoryContainer key={column.id} columnProperties={column} />
@@ -26,33 +24,43 @@ class Board extends Component {
           </DragDropContext>
         </Row>
       </Container>
-    )
+    );
   }
 
-  constructor(props) {
-    super(props);
-  }
+  // Comment out for now to avoid warnings, will need to implement in future
+  // constructor(props) {
+  //   super(props);
+  // }
 
   handleOnDragEnd = (result) => {
-    
-    if(!result.destination) {
+    if (!result.destination) {
       return;
     }
 
-    if(this.movingStoryBetweenStatuses(result.source.droppableId, result.destination.droppableId)) {
-      this.changeStoryStatus(this.state.nest, result.source, result.destination);
+    if (
+      this.movingStoryBetweenStatuses(
+        result.source.droppableId,
+        result.destination.droppableId
+      )
+    ) {
+      this.changeStoryStatus(
+        this.state.nest,
+        result.source,
+        result.destination
+      );
+    } else {
+      this.reorderStories(this.state.nest, result.source, result.destination);
     }
-    else {
-      this.reorderStories(this.state.nest, result.source, result.destination)
-    }
-  }
+  };
 
   movingStoryBetweenStatuses(sourceID, destinationID) {
     return sourceID !== destinationID;
   }
 
   reorderStories(list, source, destination) {
-    const columnIndex = list.findIndex(column => column.id === source.droppableId);
+    const columnIndex = list.findIndex(
+      (column) => column.id === source.droppableId
+    );
 
     const tempNestData = this.state.nest.slice();
     const userStories = tempNestData[columnIndex].userStories;
@@ -65,21 +73,25 @@ class Board extends Component {
   }
 
   changeStoryStatus(list, source, destination) {
-
-    const sourceColumnIndex = list.findIndex(column => column.id === source.droppableId);
-    const destinationColumnIndex = list.findIndex(column => column.id === destination.droppableId);
+    const sourceColumnIndex = list.findIndex(
+      (column) => column.id === source.droppableId
+    );
+    const destinationColumnIndex = list.findIndex(
+      (column) => column.id === destination.droppableId
+    );
 
     const tempNestData = this.state.nest.slice();
     const sourceUserStories = tempNestData[sourceColumnIndex].userStories;
-    const destinationUserStories = tempNestData[destinationColumnIndex].userStories;
-    
+    const destinationUserStories =
+      tempNestData[destinationColumnIndex].userStories;
+
     const [removed] = sourceUserStories.splice(source.index, 1);
-  
-    destinationUserStories.splice(destination.index, 0, removed)
+
+    destinationUserStories.splice(destination.index, 0, removed);
 
     this.setState({
-      nest: tempNestData
-    })
+      nest: tempNestData,
+    });
   }
 }
 

--- a/src/pages/Board/Board.js
+++ b/src/pages/Board/Board.js
@@ -1,14 +1,85 @@
 import React, { Component } from "react";
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+import UserStoryContainer from '../../components/UserStory/UserStoryContainer';
+import { NEST_MODEL } from './BoardConstants';
+import { DragDropContext } from 'react-beautiful-dnd';
 
 class Board extends Component {
-  state = {};
+  
+  state = {
+    nest: NEST_MODEL,
+  };
+
   render() {
-    return <h1>Board page loaded!</h1>;
+    return (
+      <Container id="board-container" className="container-height">
+        <Row>
+          <DragDropContext onDragEnd={this.handleOnDragEnd}>
+            {console.log('BOARD COLUMNS IN RENDER IS: ', this.state.nest)}
+            {this.state.nest.map((column) => (
+              <Col key={column.id}>
+                <UserStoryContainer key={column.id} columnProperties={column} />
+              </Col>
+            ))}
+          </DragDropContext>
+        </Row>
+      </Container>
+    )
   }
 
   constructor(props) {
     super(props);
-    console.log("props loaded: ", props);
+  }
+
+  handleOnDragEnd = (result) => {
+    
+    if(!result.destination) {
+      return;
+    }
+
+    if(this.movingStoryBetweenStatuses(result.source.droppableId, result.destination.droppableId)) {
+      this.changeStoryStatus(this.state.nest, result.source, result.destination);
+    }
+    else {
+      this.reorderStories(this.state.nest, result.source, result.destination)
+    }
+  }
+
+  movingStoryBetweenStatuses(sourceID, destinationID) {
+    return sourceID !== destinationID;
+  }
+
+  reorderStories(list, source, destination) {
+    const columnIndex = list.findIndex(column => column.id === source.droppableId);
+
+    const tempNestData = this.state.nest.slice();
+    const userStories = tempNestData[columnIndex].userStories;
+    const [removed] = userStories.splice(source.index, 1);
+    userStories.splice(destination.index, 0, removed);
+
+    this.setState({
+      nest: tempNestData,
+    });
+  }
+
+  changeStoryStatus(list, source, destination) {
+
+    const sourceColumnIndex = list.findIndex(column => column.id === source.droppableId);
+    const destinationColumnIndex = list.findIndex(column => column.id === destination.droppableId);
+
+    const tempNestData = this.state.nest.slice();
+    const sourceUserStories = tempNestData[sourceColumnIndex].userStories;
+    const destinationUserStories = tempNestData[destinationColumnIndex].userStories;
+    
+    const [removed] = sourceUserStories.splice(source.index, 1);
+  
+    destinationUserStories.splice(destination.index, 0, removed)
+
+    this.setState({
+      nest: tempNestData
+    })
   }
 }
 

--- a/src/pages/Board/BoardConstants.js
+++ b/src/pages/Board/BoardConstants.js
@@ -4,7 +4,7 @@
 const NEST_MODEL = [
   {
     title: "To-Do",
-    id: "To-Do-Column",
+    id: "TO_DO",
     showAddButton: true,
     userStories: [
       {
@@ -12,32 +12,51 @@ const NEST_MODEL = [
         title: "Creating Navbar Component",
         assignee: "Enrique Gambra",
         description:
-          "This ticket is set to track the progress for creating the navbar component. For the navbar component, we expect...",
+          "This ticket is set to track the progress for creating the navbar component. For the navbar component, we would like three items. One, a team icon, two a hamburger menu as a 'view more' option, and three a home icon.",
       },
       {
         id: "123",
         title: "Creating API Services",
         assignee: "Brian Seidl",
         description:
-          "This ticket is set to track the progress for creating the neccessary graphQL mutations and schemas. A great amount of work will be needed to R&D...",
+          "This ticket is set to track the progress for creating the neccessary graphQL mutations and schemas.",
       },
       {
         id: "12",
         title: "Creating Team Page",
         assignee: "Derrick Persaud",
         description:
-          "This ticket is set to track the progress for creating the team page. The team page will perform the following functions, 1) allow a user to add a teammate...",
+          "This ticket is set to track the progress for creating the team page. The team page will perform the following functions, 1) allow a user to add a teammate 2) remove a teammate 3) assign user permissions for a nest.",
+      },
+      {
+        id: "1",
+        title: "Create Board Page",
+        assignee: "N/A",
+        description:
+          "This ticket tracks progress for the board page. The board page or 'Nest' as we call it, will be the main hub for viewing user stories and editing their statuses.",
+      },
+      {
+        id: "777",
+        title: "Write Weekly Report",
+        assignee: "N/A",
+        description:
+          "This ticket is used to remind us we need to write the weekly report for Prof. Li's class on 4/8/2021.",
       },
     ],
   },
   {
-    title: "In Progress",
-    id: "In-Progress-Column",
+    title: "In Dev",
+    id: "IN_DEV",
     userStories: [],
   },
   {
-    title: "Finished",
-    id: "Finished-Column",
+    title: "QA",
+    id: "QA",
+    userStories: [],
+  },
+  {
+    title: "Completed",
+    id: "COMPLETED",
     userStories: [],
   },
 ];

--- a/src/pages/Board/BoardConstants.js
+++ b/src/pages/Board/BoardConstants.js
@@ -1,0 +1,43 @@
+
+// The userStories property is just mock data for now, but will be used as how we want our data
+// structured for reference
+
+const NEST_MODEL = [
+  {
+    title: 'To-Do',
+    id: 'To-Do-Column',
+    showAddButton: true,
+    userStories: [
+      {
+        id: '1234',
+        title: 'Creating Navbar Component',
+        assignee: 'Enrique Gambra',
+        description: 'This ticket is set to track the progress for creating the navbar component. For the navbar component, we expect...',
+      },
+      {
+        id: '123',
+        title: 'Creating API Services',
+        assignee: 'Brian Seidl',
+        description: 'This ticket is set to track the progress for creating the neccessary graphQL mutations and schemas. A great amount of work will be needed to R&D...'
+      },
+      {
+        id: '12',
+        title: 'Creating Team Page',
+        assignee: 'Derrick Persaud',
+        description: 'This ticket is set to track the progress for creating the team page. The team page will perform the following functions, 1) allow a user to add a teammate...',
+      }
+    ]
+  },
+  {
+    title: 'In Progress',
+    id: 'In-Progress-Column',
+    userStories: [],
+  },
+  {
+    title: 'Finished',
+    id: 'Finished-Column',
+    userStories: [],
+  }
+]
+
+export { NEST_MODEL };

--- a/src/pages/Board/BoardConstants.js
+++ b/src/pages/Board/BoardConstants.js
@@ -1,43 +1,45 @@
-
 // The userStories property is just mock data for now, but will be used as how we want our data
 // structured for reference
 
 const NEST_MODEL = [
   {
-    title: 'To-Do',
-    id: 'To-Do-Column',
+    title: "To-Do",
+    id: "To-Do-Column",
     showAddButton: true,
     userStories: [
       {
-        id: '1234',
-        title: 'Creating Navbar Component',
-        assignee: 'Enrique Gambra',
-        description: 'This ticket is set to track the progress for creating the navbar component. For the navbar component, we expect...',
+        id: "1234",
+        title: "Creating Navbar Component",
+        assignee: "Enrique Gambra",
+        description:
+          "This ticket is set to track the progress for creating the navbar component. For the navbar component, we expect...",
       },
       {
-        id: '123',
-        title: 'Creating API Services',
-        assignee: 'Brian Seidl',
-        description: 'This ticket is set to track the progress for creating the neccessary graphQL mutations and schemas. A great amount of work will be needed to R&D...'
+        id: "123",
+        title: "Creating API Services",
+        assignee: "Brian Seidl",
+        description:
+          "This ticket is set to track the progress for creating the neccessary graphQL mutations and schemas. A great amount of work will be needed to R&D...",
       },
       {
-        id: '12',
-        title: 'Creating Team Page',
-        assignee: 'Derrick Persaud',
-        description: 'This ticket is set to track the progress for creating the team page. The team page will perform the following functions, 1) allow a user to add a teammate...',
-      }
-    ]
+        id: "12",
+        title: "Creating Team Page",
+        assignee: "Derrick Persaud",
+        description:
+          "This ticket is set to track the progress for creating the team page. The team page will perform the following functions, 1) allow a user to add a teammate...",
+      },
+    ],
   },
   {
-    title: 'In Progress',
-    id: 'In-Progress-Column',
+    title: "In Progress",
+    id: "In-Progress-Column",
     userStories: [],
   },
   {
-    title: 'Finished',
-    id: 'Finished-Column',
+    title: "Finished",
+    id: "Finished-Column",
     userStories: [],
-  }
-]
+  },
+];
 
 export { NEST_MODEL };

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import { cardItems } from "./HomePageConstants";
 import Cards from "../../components/Cards/Cards";
 class Home extends Component {
+
   render() {
     return (
       <React.Fragment>
@@ -62,12 +63,6 @@ class Home extends Component {
       </React.Fragment>
     );
   }
-
-  /**
-   * Notes:
-   * - Check for if a user has any boards... make API call to receive the data...
-   * - Display a "Getting Started" component... can be static and include images, documentation, key information, etc.
-   */
 }
 
 export default Home;

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import { cardItems } from "./HomePageConstants";
 import Cards from "../../components/Cards/Cards";
 class Home extends Component {
-
   render() {
     return (
       <React.Fragment>

--- a/src/routes.js
+++ b/src/routes.js
@@ -38,7 +38,7 @@ function RouteWithSubRoutes(route) {
     <Route
       path={route.path}
       exact={route.exact}
-      render={props => <route.component {...props} routes={route.routes} />}
+      render={(props) => <route.component {...props} routes={route.routes} />}
     />
   );
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -12,19 +12,19 @@ const ROUTES = [
     path: "/",
     key: "HOME",
     exact: true,
-    component: () => <Home />,
+    component: Home,
   },
   {
     path: "/epics",
     key: "EPICS",
     exact: true,
-    component: () => <Epics />,
+    component: Epics,
   },
   {
     path: "/board",
     key: "BOARD",
     exact: true,
-    component: () => <Board />,
+    component: Board,
   },
 ];
 
@@ -38,7 +38,7 @@ function RouteWithSubRoutes(route) {
     <Route
       path={route.path}
       exact={route.exact}
-      render={(props) => <route.component {...props} routes={route.routes} />}
+      render={props => <route.component {...props} routes={route.routes} />}
     />
   );
 }


### PR DESCRIPTION
@brianseidl  @DerrickPersaud 
- Created the initial board view with some mock data for now, API calls and actual pulling of data to be in a future commit. Able to implement drag and drop feature for user stories
![boards-page](https://user-images.githubusercontent.com/35939613/113661647-7d731980-9674-11eb-8569-dd0af19a4424.JPG)
- Moved the amplify sign out component to when we select the user icon. NOTE: We will have to change the theme of the amplify sign out component which is going to be a hassle after some research, so this will be included in a future commit
![icon-sign-out](https://user-images.githubusercontent.com/35939613/113661840-d8a50c00-9674-11eb-975f-2752343439b7.JPG)
- Added graphQL API call to grab nests for a user and display them in the sidebar. They are triggered by clicking the "My Boards" icon to display
![my-boards](https://user-images.githubusercontent.com/35939613/113661916-068a5080-9675-11eb-9469-a786fb5b7128.JPG)


